### PR TITLE
Change way to access events handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+* Changed the way to access the events handler:
+
+```js
+// new way
+import { events } from '@gosquared/logs2';
+
+// commonjs
+const { events } = require('@gosquared/logs2');
+
+// old way (avoid)
+const events = require('@gosquared/logs2/dist/src/events');
+```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ async function stop() {
 Errors are emitted as events:
 
 ```javascript
-const events = require('@gosquared/logs2/dist/src/events');
+const { events } = require('@gosquared/logs2');
 events.on('error', e => {
   console.error(e);
 });

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,7 @@
 import { get as getCw } from './src/aws';
 import Logger from "./src/logger";
 import { Settings } from './types';
+import events from './src/events';
 
 const loggers: Map<string, Logger> = new Map();
 
@@ -22,3 +23,4 @@ export async function stop() {
   }
 }
 
+export { events };

--- a/test/limits.ts
+++ b/test/limits.ts
@@ -1,0 +1,21 @@
+import assert from 'assert';
+import { getLogger, events } from '../main';
+
+describe('limits', () => {
+  it('clears queue when messsage limit reached', done => {
+    const group = 'test';
+    const settings = {};
+    const logger = getLogger(group, settings);
+    logger.limit = 1;
+
+    events.once('error', e => {
+      assert.strictEqual<string>(
+        e.message,
+        'message limit reached'
+      );
+      done();
+    });
+
+    logger.log('test', {});
+  });
+})


### PR DESCRIPTION
* Changed the way to access the events handler:

```js
// new way
import { events } from '@gosquared/logs2';

// commonjs
const { events } = require('@gosquared/logs2');

// old way (avoid)
const events = require('@gosquared/logs2/dist/src/events');
```
